### PR TITLE
[systemsettings] Read bluetooth address from /var/lib/bluetooth instead

### DIFF
--- a/src/aboutsettings.cpp
+++ b/src/aboutsettings.cpp
@@ -32,6 +32,7 @@
 #include "aboutsettings.h"
 
 #include <QDebug>
+#include <QDir>
 #include <QStringList>
 #include <QStorageInfo>
 #include <QNetworkInfo>
@@ -62,7 +63,15 @@ qlonglong AboutSettings::availableDiskSpace() const
 
 const QString AboutSettings::bluetoothAddress() const
 {
-    return m_netinfo->macAddress(QNetworkInfo::BluetoothMode, 0);
+    QRegExp addressPattern("(\\w{2}:){5}\\w{2}");
+    QDir bluezAdapterDir("/var/lib/bluetooth/");
+    QStringList dirs = bluezAdapterDir.entryList();
+    Q_FOREACH(const QString &dir, dirs) {
+        if (addressPattern.exactMatch(dir)) {
+            return dir;
+        }
+    }
+    return QString();
 }
 
 const QString AboutSettings::wlanMacAddress() const


### PR DESCRIPTION
QNetworkInfo reads the address from /sys/class/bluetooth/hci0/address
which is set to "00:00:00:00:00:00" if the adapter was not available
at time of query.
