### PR TITLE
Adjust device and software information that AboutSettings returns

### DIFF
--- a/src/aboutsettings.cpp
+++ b/src/aboutsettings.cpp
@@ -36,6 +36,8 @@
 #include <QStorageInfo>
 #include <QNetworkInfo>
 #include <QDeviceInfo>
+#include <QFile>
+#include <QByteArray>
 
 AboutSettings::AboutSettings(QObject *parent)
     : QObject(parent),
@@ -75,5 +77,23 @@ QString AboutSettings::imei() const
     return m_devinfo->imei(0);
 }
 
+QString AboutSettings::softwareVersion() const
+{
+    QFile releaseFile("/etc/os-release");
+    if (!releaseFile.open(QIODevice::ReadOnly | QIODevice::Text))
+        return QString();
 
+    QString version;
+    QByteArray versionTag("VERSION=");
 
+    while (!releaseFile.atEnd()) {
+        QByteArray line = releaseFile.readLine();
+
+        if (line.startsWith(versionTag)) {
+            version = line.mid(versionTag.length()).simplified();
+            break;
+        }
+    }
+
+    return version;
+}

--- a/src/aboutsettings.h
+++ b/src/aboutsettings.h
@@ -44,6 +44,7 @@ class AboutSettings: public QObject
     Q_PROPERTY(QString bluetoothAddress READ bluetoothAddress CONSTANT)
     Q_PROPERTY(QString wlanMacAddress READ wlanMacAddress CONSTANT)
     Q_PROPERTY(QString imei READ imei CONSTANT)
+    Q_PROPERTY(QString softwareVersion READ softwareVersion CONSTANT)
 
 public:
     explicit AboutSettings(QObject *parent = 0);
@@ -55,6 +56,7 @@ public:
     QString bluetoothAddress() const;
     QString wlanMacAddress() const;
     QString imei() const;
+    QString softwareVersion() const;
 
 private:
     QStorageInfo *m_sysinfo;


### PR DESCRIPTION
Qtsystems is currently confusing quite a bit what is hw/sw manufacturer, version, name, etc. Avoid using such information.

Added support for getting software version directly from /etc/os-release
