### PR TITLE
[systemsettings] Add support for host mode switching

### DIFF
--- a/rpm/nemo-qml-plugin-systemsettings.spec
+++ b/rpm/nemo-qml-plugin-systemsettings.spec
@@ -9,7 +9,7 @@ Name:       nemo-qml-plugin-systemsettings
 # << macros
 
 Summary:    System settings plugin for Nemo Mobile
-Version:    0.0.10
+Version:    0.0.11
 Release:    1
 Group:      System/Libraries
 License:    BSD
@@ -20,7 +20,7 @@ Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5SystemInfo)
-BuildRequires:  pkgconfig(qmsystem2-qt5)  >= 1.4.15
+BuildRequires:  pkgconfig(qmsystem2-qt5)  >= 1.4.17
 BuildRequires:  pkgconfig(timed-qt5)
 BuildRequires:  pkgconfig(profile)
 BuildRequires:  pkgconfig(mce)

--- a/src/usbsettings.h
+++ b/src/usbsettings.h
@@ -60,6 +60,7 @@ public:
         MTP = MeeGo::QmUSBMode::MTP,
         Adb = MeeGo::QmUSBMode::Adb,
         Diag = MeeGo::QmUSBMode::Diag,
+        Host = MeeGo::QmUSBMode::Host,
         ConnectionSharing = MeeGo::QmUSBMode::ConnectionSharing
     };
 


### PR DESCRIPTION
Support usb_modeds switching of USB to host mode (for fake otg)

Signed-off-by: Philippe De Swert philippe.deswert@jollamobile.com
