### PR TITLE
[systemsettings] Add dedicated charger USB mode. Contributes: JB#15195

### DIFF
--- a/rpm/nemo-qml-plugin-systemsettings.spec
+++ b/rpm/nemo-qml-plugin-systemsettings.spec
@@ -1,6 +1,6 @@
 Name:       nemo-qml-plugin-systemsettings
 Summary:    System settings plugin for Nemo Mobile
-Version:    0.0.27
+Version:    0.0.28
 Release:    1
 Group:      System/Libraries
 License:    BSD

--- a/src/usbsettings.h
+++ b/src/usbsettings.h
@@ -61,6 +61,7 @@ public:
         Adb = MeeGo::QmUSBMode::Adb,
         Diag = MeeGo::QmUSBMode::Diag,
         Host = MeeGo::QmUSBMode::Host,
+        Charger = MeeGo::QmUSBMode::Charger,
         ConnectionSharing = MeeGo::QmUSBMode::ConnectionSharing
     };
 


### PR DESCRIPTION
Have the dedicated charger mode forwarded from qmsystem so we can
use it in the settings.

Signed-off-by: Philippe De Swert philippe.deswert@jollamobile.com
