### PR TITLE
[devmode] Fast, file-based developer mode check (Fixes JB#20585)

### DIFF
--- a/src/developermodesettings.h
+++ b/src/developermodesettings.h
@@ -155,7 +155,6 @@ public slots:
     void onInstallPackageResult(QString packageName, bool success);
     void onRemovePackageResult(QString packageName, bool success);
     void onPackageProgressChanged(QString packageName, int progress);
-    void onCheckInstalledResult(QString packageName, bool installed);
 
 signals:
     void statusChanged(bool working, enum DeveloperModeSettings::Status status);


### PR DESCRIPTION
Instead of querying store-client which could take a while if the rpmdb is not hot or if there's some other transaction going on, just check for the existence of the file (which is basically the fallback solution that was already implemented if the store-client returned an error).