### PR TITLE
[aboutsettings] Return serial number (Contributes to JB#26713)

### DIFF
--- a/src/aboutsettings.cpp
+++ b/src/aboutsettings.cpp
@@ -151,6 +151,22 @@ QString AboutSettings::imei() const
     return m_devinfo->imei(0);
 }
 
+QString AboutSettings::serial() const
+{
+    // XXX: For now, this is specific to the Jolla Tablet; eventually we should
+    // use QDeviceInfo's uniqueDeviceID(), but that does not always return the
+    // serial number, so this is our best bet for the short term (this will not
+    // show any serial number on the Phone, there we have the IMEI instead).
+
+    QFile serial_txt("/config/serial/serial.txt");
+    if (serial_txt.exists()) {
+        serial_txt.open(QIODevice::ReadOnly);
+        return QString::fromUtf8(serial_txt.readAll());
+    } else {
+        return "";
+    }
+}
+
 QString AboutSettings::softwareVersion() const
 {
     return parseReleaseFile("/etc/os-release")["VERSION"];

--- a/src/aboutsettings.h
+++ b/src/aboutsettings.h
@@ -44,6 +44,7 @@ class AboutSettings: public QObject
     Q_PROPERTY(QString bluetoothAddress READ bluetoothAddress CONSTANT)
     Q_PROPERTY(QString wlanMacAddress READ wlanMacAddress CONSTANT)
     Q_PROPERTY(QString imei READ imei CONSTANT)
+    Q_PROPERTY(QString serial READ serial CONSTANT)
     Q_PROPERTY(QString softwareVersion READ softwareVersion CONSTANT)
     Q_PROPERTY(QString adaptationVersion READ adaptationVersion CONSTANT)
 
@@ -57,6 +58,7 @@ public:
     QString bluetoothAddress() const;
     QString wlanMacAddress() const;
     QString imei() const;
+    QString serial() const;
     QString softwareVersion() const;
     QString adaptationVersion() const;
 


### PR DESCRIPTION
For showing the serial number on the tablet. This doesn't require "txeireader", as this is provided by the pattern, and there's no good way we could do this for i486 targets where "txeireader" is not available, so we just assume it's installed on the tablet and nowhere else for now.