### PR TITLE
[nemo-qml-plugin-systemsettings] Add removable storage model. Contributes to MER#1334

### DIFF
--- a/src/aboutsettings.h
+++ b/src/aboutsettings.h
@@ -49,6 +49,9 @@ class AboutSettings: public QObject
     Q_PROPERTY(QString softwareVersion READ softwareVersion CONSTANT)
     Q_PROPERTY(QString adaptationVersion READ adaptationVersion CONSTANT)
 
+    Q_PROPERTY(QVariant internalStorageUsageModel READ diskUsageModel NOTIFY storageChanged)
+    Q_PROPERTY(QVariant externalStorageUsageModel READ externalStorageUsageModel NOTIFY storageChanged)
+
 public:
     explicit AboutSettings(QObject *parent = 0);
     virtual ~AboutSettings();
@@ -66,6 +69,8 @@ public:
      *  - total: total bytes on the storage
      **/
     Q_INVOKABLE QVariant diskUsageModel() const;
+    QVariant externalStorageUsageModel() const;
+    Q_INVOKABLE void refreshStorageModels();
 
     QString bluetoothAddress() const;
     QString wlanMacAddress() const;
@@ -74,10 +79,16 @@ public:
     QString softwareVersion() const;
     QString adaptationVersion() const;
 
+signals:
+    void storageChanged();
+
 private:
     QStorageInfo *m_sysinfo;
     QNetworkInfo *m_netinfo;
     QDeviceInfo *m_devinfo;
+
+    QVariantList m_internalStorage;
+    QVariantList m_externalStorage;
 };
 
 #endif

--- a/src/src.pro
+++ b/src/src.pro
@@ -2,7 +2,7 @@ TEMPLATE = lib
 TARGET = systemsettings
 
 # TODO: hide_symbols
-CONFIG += qt create_pc create_prl no_install_prl
+CONFIG += qt create_pc create_prl no_install_prl c++11
 QT += qml dbus systeminfo
 QT -= gui
 


### PR DESCRIPTION
Add a simple removable media model. The available removable media is
currently limit to /dev/mmcblk1* devices. This is to match what
sd-utils (git@github.com:nemomobile/sd-utils.git) supports.

libblkid is used to try and detect the file system used on unmounted
partitions. Depending on the version of libblkid available on the
device, some file system types may not be detected.